### PR TITLE
Ansible key file location fix for hands-off Ansible run

### DIFF
--- a/provisioning/hosts
+++ b/provisioning/hosts
@@ -1,1 +1,1 @@
-omeroserver ansible_ssh_host=192.168.33.10 ansible_ssh_user=root ansible_ssh_private_key_file=../.vagrant/machines/default/virtualbox/private_key
+omeroserver ansible_ssh_host=192.168.33.10 ansible_ssh_user=root ansible_ssh_private_key_file=~/.vagrant.d/insecure_private_key


### PR DESCRIPTION
Ansible key file doesn't exist in .vagrant automatically, but it does exist in ~/.vagrant.d/ in a standard Ansible install.

This fix should make the `ansible-playbook -i hosts omero_install.yml` step work straight off, without having to add the ansible_insecure_key to that folder.
