### PR TITLE
Added the OMERO server user `root` to the vars-template.yml, extracted from Ansible OMERO task

### DIFF
--- a/provisioning/roles/omero/tasks/main.yml
+++ b/provisioning/roles/omero/tasks/main.yml
@@ -122,7 +122,7 @@
 - name: create omero sql script
   sudo: yes
   sudo_user: "{{ omero_user_name }}"
-  command: "{{ omero_cmd }} db script --password=omero"
+  command: "{{ omero_cmd }} db script --password {{ omero_root_password  }}"
   args:
     creates: "{{ omero_home }}/OMERO5.1__1.sql"
   register: created_omero_sql_script

--- a/provisioning/vars-template.yml
+++ b/provisioning/vars-template.yml
@@ -5,11 +5,14 @@
 omero_version: 5.1.0
 omero_branch: b40
 
-# OMERO user configuration.
+# OMERO OS user configuration.
 omero_user_name: omero
 omero_uid: 10949
 omero_user_password: "$6$rounds=100000$4575ms0oqKD2OFi6$UJ68Uq80NOn8jrQ64e4.OqQoW/KXfga4lndzBqLNo8NdzHIvW7.shMsIhD9YqBlGIq.f6/T.S5sjX7WWUj7KD."
 omero_home: /home/{{ omero_user_name }}
+
+# OMERO server user configuration
+omero_root_password: omero_root_password
 
 # OMERO directory and command aliases.
 omero_server_link: OMERO.server


### PR DESCRIPTION
Clarified OS user v.s. OMERO server user in `vars-template.yml`, added OMERO server user root password to the vars-template.yml, rather than the 'omero' ansible task.
